### PR TITLE
Fix NameError by initializing html_pdf_url

### DIFF
--- a/src/courtlistener.py
+++ b/src/courtlistener.py
@@ -408,14 +408,15 @@ def build_complaint_documents_from_hits(
             url = data.get("next")
     
         print(f"[DEBUG] total RECAP docs fetched={len(docs)}")
-        
+        # 🔥 FIX: initialize fallback variables (avoid NameError / leakage)
+        html_pdf_url = ""    
+
         # =====================================================
         # ✅ BEST PRACTICE: RECAP → HTML fallback
         # =====================================================
-        if not docs:        
-            if recap_doc_count == 0:            
-                print("[DEBUG] RECAP empty → HTML fallback activated")
-                html_pdf_url = _extract_first_pdf_from_docket_html(did)
+        if not docs:
+            print("[DEBUG] RECAP empty → HTML fallback activated")
+            html_pdf_url = _extract_first_pdf_from_docket_html(did)
 
             if html_pdf_url:
                 snippet = extract_pdf_text(html_pdf_url, max_chars=3000)


### PR DESCRIPTION
Initialize fallback variable to avoid NameError and ensure proper handling when RECAP docs are empty.