### PR TITLE
Feat: 중복 제거 비교 범위를 모든 댓글로 확장

### DIFF
--- a/src/github_issue.py
+++ b/src/github_issue.py
@@ -83,11 +83,5 @@ def list_comments(owner: str, repo: str, token: str, issue_number: int) -> list[
     return r.json() or []
 
 
-def get_first_comment_body(owner: str, repo: str, token: str, issue_number: int) -> str | None:
-    comments = list_comments(owner, repo, token, issue_number)
-    if not comments:
-        return None
 
-    # GitHub API는 오래된 순 정렬
-    return comments[0].get("body")
 


### PR DESCRIPTION
## 개요
기존에는 당일 첫 번째 댓글만을 기준으로 중복 여부를 판단했으나, 이를 확장하여 첫 번째 댓글부터 마지막 댓글까지 모든 이전 댓글들을 비교 대상으로 하도록 수정했습니다.
## 변경 사항
1. **중복 체크 범위 확장 (src/run.py)**:
   - list_comments로 가져온 모든 댓글을 순회하며 이미 출력된 뉴스 URL과 사건(Docket) 번호를 수집합니다.
   - 수집된 정보를 바탕으로 현재 데이터의 중복 여부를 판단하고 skip 처리합니다.
2. **불필요한 코드 제거 및 정리**:
   - 더 이상 사용되지 않는 get_first_comment_body 함수를 src/github_issue.py에서 제거하고 관련 임포트를 업데이트했습니다.
## 기대 효과
- 당일 업무 중 여러 번 수집이 이루어지더라도, 이전에 보고된 내용은 중복으로 정확히 필터링되어 리포트의 가독성이 향상됩니다.