### PR TITLE
fix: improve analysis logic in src and fix UI/KPI bugs

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 def debug_log(msg: str):
     """
@@ -6,3 +7,14 @@ def debug_log(msg: str):
     """
     if os.environ.get("DEBUG") == "1":
         print(f"[DEBUG] {msg}")
+
+def slugify_case_name(name: str) -> str:
+    """
+    Case name을 URL에 적합한 slug 형태로 변환합니다.
+    """
+    name = (name or "").lower()
+    name = name.replace("v.", "v")
+    name = re.sub(r"[^a-z0-9\s-]", "", name)
+    name = re.sub(r"\s+", "-", name)
+    name = re.sub(r"-+", "-", name)
+    return name.strip("-")


### PR DESCRIPTION
1. 

src/utils.py
 (공통 모듈)
공통 함수 추가: 중복 구현되던 

slugify_case_name
 로직을 공통 함수로 통합하여 일관성을 확보했습니다.
2. 

src/complaint_parse.py
 (분석 엔진 개선)
추출 정확도 향상: re.DOTALL 플래그를 추가하여 줄바꿈이 포함된 법원 문서에서도 핵심 문맥을 정확하게 포착하도록 수정했습니다.
당사자 추출 필터링: 법원 명칭(DISTRICT COURT 등)이 당사자로 오검출되는 문제를 방지하는 필터링 로직을 추가했습니다.
3. 

src/render.py
 (UI/UX 및 리팩토링)
정렬 로직 보정: "미확인" 데이터가 정렬 상단에 노출되지 않도록 정렬 키 처리를 개선했습니다.
테이블 가독성: 빈 링크 표시를 None에서 -로 변경하고, 공통 슬러그 함수를 적용했습니다.
4. 

src/run.py
 (KPI 및 리포트 보정)
문서 건수 계산 버그 수정: HTML fallback 문서를 포함하여 전체 문서 건수(recap_doc_count)가 정확하게 산출되도록 수정했습니다.
Slack 리포트 일관성: Slack 전송 링크의 슬러그 생성 방식을 공통 함수로 통합했습니다.