### PR TITLE
docs: update risk evaluation criteria in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,18 @@ Repository → Settings → Secrets and variables → Actions → Variables 탭
 
 ## 📊 위험도 평가 기준 (Evaluation Matrix)
 
-| 항목 | 조건 | 점수 |
+| 항목 | 조건 (주요 키워드) | 점수 |
 |---|---|---|
-| 무단 데이터 수집 | scrape / crawl / ingest | +30 |
-| 모델 학습 직접 언급 | train / training / model | +30 |
-| 상업적 사용 | commercial / profit | +15 |
-| 저작권 소송 (NOS 820) | Nature = 820 Copyright | +15 |
-| 집단소송 | class action | +10 |
+| 무단 데이터 수집 명시 | scrape, crawl, ingest, harvest, mining, bulk, robots.txt, unauthorized 등 | +30 |
+| 모델 학습 직접 언급 | train, model, llm, generative ai, gpt, transformer, diffusion, inference 등 | +30 |
+| 상업적 사용 | commercial, profit, monetiz, revenue, subscription, enterprise 등 | +15 |
+| 저작권 소송/쟁점 | Nature=820, copyright, infringement, dmca, fair use, exclusive 등 | +15 |
+| 집단소송 | class action, putative class, representative 등 | +10 |
 
-- **80~100 🔥**: 무단 수집 + 학습 + 상업 사용 (고위험)
-- **60~79 ⚠️**: 모델 학습 직접 언급
-- **40~59 🟡**: 학습 쟁점 존재
-- **0~39 🟢**: 간접 연관 또는 일반 소송
+- **80~100 🔥**: 무단 수집 + 학습 + 상업적 사용 (고위험 리스크)
+- **60~79 ⚠️**: 모델 학습 직접 언급 및 관련 쟁점 수반
+- **40~59 🟡**: 학습 데이터 관련 법적 쟁점 존재
+- **0~39 🟢**: 간접 연관 또는 일반적인 주변 이슈
 
 ## 📝 참고 사항
 - **RECAP 데이터**: PACER에 등록된 문서 중 "공개(RECAP)"된 문서만 접근 가능합니다. 문서가 없는 경우 힌트 정보만 제공됩니다.


### PR DESCRIPTION
📝 README 업데이트 내용
주요 키워드 보강: scrape, train, commercial, copyright, class action 등 각 카테고리별로 실제 코드에서 사용하는 최신 키워드들을 표에 반영했습니다.
설명 정교화: 위험도 등급별 상세 설명을 코드의 로직과 일치하도록 수정했습니다.

- 80~100 🔥: 무단 수집 + 학습 + 상업적 사용 (고위험 리스크)
- 60~79 ⚠️: 모델 학습 직접 언급 및 관련 쟁점 수반
- 40~59 🟡: 학습 데이터 관련 법적 쟁점 존재
- 0~39 🟢: 간접 연관 또는 일반적인 주변 이슈