### PR TITLE
Refactor: remove duplicate items from GitHub Issue output and log the…

### DIFF
--- a/src/dedup.py
+++ b/src/dedup.py
@@ -100,23 +100,16 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
 
         header_line, separator_line = n_table_meta
         non_skip_rows = []
-        skip_rows = []
 
         for r in n_rows:
             url = extract_article_url(r[title_idx])
             if url in base_article_set:
-                new_row = []
-                for i, col in enumerate(r):
-                    if i in (no_idx, date_idx, title_idx):
-                        new_row.append(col)
-                    else:
-                        new_row.append("skip")
-                skip_rows.append(new_row)
+                debug_log(f"Skipping duplicate News: {r[title_idx]} ({url})")
             else:
                 non_skip_rows.append(r)
                 new_article_count += 1
         
-        final_rows = non_skip_rows + skip_rows
+        final_rows = non_skip_rows
         new_lines = [header_line, separator_line]
         for row_idx, r in enumerate(final_rows, start=1):
             if no_idx is not None:
@@ -141,23 +134,16 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
 
         header_line, separator_line = c_table_meta
         non_skip_rows = []
-        skip_rows = []
 
         for r in c_rows:
             docket = r[docket_idx]
             if docket in base_docket_set:
-                new_row = []
-                for i, col in enumerate(r):
-                    if i in (no_idx, status_idx, case_idx, docket_idx):
-                        new_row.append(col)
-                    else:
-                        new_row.append("skip")
-                skip_rows.append(new_row)
+                debug_log(f"Skipping duplicate Case: {r[case_idx]} ({docket})")
             else:
                 non_skip_rows.append(r)
                 new_docket_count += 1
 
-        final_rows = non_skip_rows + skip_rows
+        final_rows = non_skip_rows
         new_lines = [header_line, separator_line]
         for row_idx, r in enumerate(final_rows, start=1):
             if no_idx is not None:


### PR DESCRIPTION
주요 변경 사항

src/dedup.py  수정:
중복 제거 로직 변경: 이전에는 중복된 항목의 셀 내용을 "skip"으로 치환하여 테이블에 유지했으나, 이제는 해당 행(row)을 전체 결과(final_rows)에서 완전히 제외하도록 수정하였습니다.
디버깅 로그 추가: 제외된 항목들은 사용자 요청에 따라 debug_log를 통해 콘솔에만 출력되도록 처리하였습니다.
News: Skipping duplicate News: [기사제목] ([URL])
Cases: Skipping duplicate Case: [케이스명] ([도켓번호])
번호 재할당: 중복 항목이 제외된 후에도 테이블의 No. 컬럼이 1부터 순차적으로 올바르게 매겨지도록 기존의 re-numbering 로직을 유지하였습니다.
작업 결과 확인
GitHub Issue: 이제 이전에 이미 올라왔던 뉴스나 소송 건은 리포트 테이블에 나타나지 않으며, 새로 발견된 항목들만 깔끔하게 표시됩니다.
콘솔 로그: 중복되어 제외된 항목들은 실행 시 콘솔(debug_log)에 표시되어, 어떤 데이터가 건너뛰어졌는지 확인할 수 있습니다.
PR 제출
현재 변경 사항은 아래 브랜치에 푸시되어 있습니다:

Branch: remove-duplicate-skips
Target: main