### PR TITLE
Remove duplicate skips

### DIFF
--- a/src/dedup.py
+++ b/src/dedup.py
@@ -110,13 +110,16 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
                 new_article_count += 1
         
         final_rows = non_skip_rows
-        new_lines = [header_line, separator_line]
-        for row_idx, r in enumerate(final_rows, start=1):
-            if no_idx is not None:
-                r[no_idx] = str(row_idx)
-            new_lines.append("| " + " | ".join(r) + " |")
+        if not final_rows:
+            new_news_section = "새로운 소식이 0건입니다.\n"
+        else:
+            new_lines = [header_line, separator_line]
+            for row_idx, r in enumerate(final_rows, start=1):
+                if no_idx is not None:
+                    r[no_idx] = str(row_idx)
+                new_lines.append("| " + " | ".join(r) + " |")
+            new_news_section = "\n".join(new_lines)
 
-        new_news_section = "\n".join(new_lines)
         current_md = current_md.replace(news_section, new_news_section)
 
     # 3) 현재 Markdown 처리 (Cases)
@@ -144,13 +147,16 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
                 new_docket_count += 1
 
         final_rows = non_skip_rows
-        new_lines = [header_line, separator_line]
-        for row_idx, r in enumerate(final_rows, start=1):
-            if no_idx is not None:
-                r[no_idx] = str(row_idx)
-            new_lines.append("| " + " | ".join(r) + " |")
+        if not final_rows:
+            new_recap_section = "새로운 소식이 0건입니다.\n"
+        else:
+            new_lines = [header_line, separator_line]
+            for row_idx, r in enumerate(final_rows, start=1):
+                if no_idx is not None:
+                    r[no_idx] = str(row_idx)
+                new_lines.append("| " + " | ".join(r) + " |")
+            new_recap_section = "\n".join(new_lines)
 
-        new_recap_section = "\n".join(new_lines)
         current_md = current_md.replace(recap_section, new_recap_section)
 
     # 4) 중복 제거 요약 생성

--- a/src/render.py
+++ b/src/render.py
@@ -181,9 +181,12 @@ def render_markdown(
             lines.append("")
 
     # 뉴스 테이블
-    if lawsuits:
+    lines.append("## 📰 News")
+    if not lawsuits:
+        lines.append("새로운 소식이 0건입니다.")
+        lines.append("")
+    else:
         debug_log("'News' is printed.")            
-        lines.append("## 📰 News")
         lines.append("| No. | 기사일자⬇️ | 제목 | 소송번호 | 소송사유 | 위험도 예측 점수 |")
         lines.append(_md_sep(6))
 
@@ -210,7 +213,11 @@ def render_markdown(
         lines.append("")
 
     # RECAP 케이스
-    if cl_cases:
+    lines.append("## ⚖️ Cases (Courtlistener+RECAP)\n")
+    if not cl_cases:
+        lines.append("새로운 소식이 0건입니다.")
+        lines.append("")
+    else:
         
         # CLDocument를 docket_id 기준으로 매핑
         doc_map = {}
@@ -218,7 +225,6 @@ def render_markdown(
             if d.docket_id:
                 doc_map[d.docket_id] = d
         
-        lines.append("## ⚖️ Cases (Courtlistener+RECAP)\n")
         lines.append(
             "| No. | 상태 | 케이스명 | 도켓번호 | Nature | 위험도 | "
             "소송이유 | AI학습관련 핵심주장 | 법적 근거 | 담당판사 | 법원 | "


### PR DESCRIPTION
GitHub Issue 리포트에서 중복 항목을 제거하고, 신규 데이터가 없을 때의 메시지 처리("새로운 소식이 0건입니다.")까지 모든 수정을 완료하여 브랜치에 반영되었습니다.

적용된 변경 사항 요약

중복 항목 제거 및 로깅 (src/dedup.py):
기존에 "skip"으로 표시되며 테이블 공간을 차지하던 중복 뉴스 및 소송 건을 결과 리포트에서 완전히 제외하도록 수정했습니다.
제외된 항목의 상세 정보(제목/URL, 케이스명/도켓번호)는 추후 확인을 위해 **콘솔 디버그 로그(debug_log)**로만 출력되도록 처리했습니다.

결과 0건 처리 (src/render.py, src/dedup.py):
필터링 결과 새로운 소식이 0건일 경우, 빈 테이블 헤더 대신 **"새로운 소식이 0건입니다."**라는 명확한 메시지를 표시하도록 개선했습니다. 이는 초기 렌더링 단계(render.py)와 중복 제거 필터링 단계(dedup.py) 모두에 적용되어, 어떤 단계에서든 결과가 없을 때 일관된 UI를 유지합니다.

PR 및 브랜치 정보
작업 브랜치: remove-duplicate-skips
커밋 메시지:
Refactor: remove duplicate items from GitHub Issue output and log them instead
Refactor: display message for empty news/cases and improve 0 results handling