### PR TITLE
Improve display for 0 items in News and Cases sections

### DIFF
--- a/src/dedup.py
+++ b/src/dedup.py
@@ -109,14 +109,16 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
                 non_skip_rows.append(r)
                 new_article_count += 1
         
-        final_rows = non_skip_rows
-        new_lines = [header_line, separator_line]
-        for row_idx, r in enumerate(final_rows, start=1):
-            if no_idx is not None:
-                r[no_idx] = str(row_idx)
-            new_lines.append("| " + " | ".join(r) + " |")
-
-        new_news_section = "\n".join(new_lines)
+        if new_article_count == 0:
+            new_news_section = "새로운 소식이 0건입니다.\n"
+        else:
+            final_rows = non_skip_rows
+            new_lines = [header_line, separator_line]
+            for row_idx, r in enumerate(final_rows, start=1):
+                if no_idx is not None:
+                    r[no_idx] = str(row_idx)
+                new_lines.append("| " + " | ".join(r) + " |")
+            new_news_section = "\n".join(new_lines)
         current_md = current_md.replace(news_section, new_news_section)
 
     # 3) 현재 Markdown 처리 (Cases)
@@ -126,7 +128,7 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
     new_docket_count = 0
     total_docket_count = len(c_rows)
 
-    if n_headers and "도켓번호" in c_headers:
+    if c_headers and "도켓번호" in c_headers:
         docket_idx = c_headers.index("도켓번호")
         no_idx = c_headers.index("No.") if "No." in c_headers else None
         status_idx = c_headers.index("상태") if "상태" in c_headers else None
@@ -143,14 +145,16 @@ def apply_deduplication(md: str, comments: List[dict]) -> str:
                 non_skip_rows.append(r)
                 new_docket_count += 1
 
-        final_rows = non_skip_rows
-        new_lines = [header_line, separator_line]
-        for row_idx, r in enumerate(final_rows, start=1):
-            if no_idx is not None:
-                r[no_idx] = str(row_idx)
-            new_lines.append("| " + " | ".join(r) + " |")
-
-        new_recap_section = "\n".join(new_lines)
+        if new_docket_count == 0:
+            new_recap_section = "새로운 소식이 0건입니다.\n"
+        else:
+            final_rows = non_skip_rows
+            new_lines = [header_line, separator_line]
+            for row_idx, r in enumerate(final_rows, start=1):
+                if no_idx is not None:
+                    r[no_idx] = str(row_idx)
+                new_lines.append("| " + " | ".join(r) + " |")
+            new_recap_section = "\n".join(new_lines)
         current_md = current_md.replace(recap_section, new_recap_section)
 
     # 4) 중복 제거 요약 생성

--- a/src/render.py
+++ b/src/render.py
@@ -181,9 +181,9 @@ def render_markdown(
             lines.append("")
 
     # 뉴스 테이블
+    lines.append("## 📰 News")
     if lawsuits:
         debug_log("'News' is printed.")            
-        lines.append("## 📰 News")
         lines.append("| No. | 기사일자⬇️ | 제목 | 소송번호 | 소송사유 | 위험도 예측 점수 |")
         lines.append(_md_sep(6))
 
@@ -208,8 +208,11 @@ def render_markdown(
                 f"{format_risk(risk_score)} |"
             )
         lines.append("")
+    else:
+        lines.append("새로운 소식이 0건입니다.\n")
 
     # RECAP 케이스
+    lines.append("## ⚖️ Cases (Courtlistener+RECAP)")
     if cl_cases:
         
         # CLDocument를 docket_id 기준으로 매핑
@@ -218,7 +221,6 @@ def render_markdown(
             if d.docket_id:
                 doc_map[d.docket_id] = d
         
-        lines.append("## ⚖️ Cases (Courtlistener+RECAP)\n")
         lines.append(
             "| No. | 상태 | 케이스명 | 도켓번호 | Nature | 위험도 | "
             "소송이유 | AI학습관련 핵심주장 | 법적 근거 | 담당판사 | 법원 | "
@@ -302,6 +304,9 @@ def render_markdown(
                     f"{complaint_link_display} | "
                     f"{_esc(c.recent_updates)} |"
                 )
+        lines.append("")
+    else:
+        lines.append("새로운 소식이 0건입니다.\n")
 
     # RECAP 법원 문서 (.pdf format)
     if cl_docs:


### PR DESCRIPTION
<h2 id="user-content--whats-been-done-so-far" style="--tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction: ; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(67 128 180 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style: ; box-sizing: border-box; border-width: 0px; border-style: solid; border-color: rgb(229, 231, 235); font-size: 1rem; font-weight: 600; margin: 0px 0px 0.5rem; color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What’s been done so far</h2><div class="my-4 rounded-lg overflow-hidden border border-gray-500/20 [&amp;_thead_tr:first-child_th:first-child]:border-t-0 [&amp;_thead_tr:first-child_th:first-child]:border-l-0 [&amp;_thead_tr:first-child_th:last-child]:border-t-0 [&amp;_thead_tr:first-child_th:last-child]:border-r-0 [&amp;_tbody_tr:last-child_td:first-child]:border-b-0 [&amp;_tbody_tr:last-child_td:first-child]:border-l-0 [&amp;_tbody_tr:last-child_td:last-child]:border-b-0 [&amp;_tbody_tr:last-child_td:last-child]:border-r-0 [&amp;_thead_tr:first-child_th]:border-t-0 [&amp;_tbody_tr:last-child_td]:border-b-0 [&amp;_th:first-child]:border-l-0 [&amp;_td:first-child]:border-l-0 [&amp;_th:last-child]:border-r-0 [&amp;_td:last-child]:border-r-0" style="--tw-border-spacing-x: 0; --tw-border-spacing-y: 0; --tw-translate-x: 0; --tw-translate-y: 0; --tw-rotate: 0; --tw-skew-x: 0; --tw-skew-y: 0; --tw-scale-x: 1; --tw-scale-y: 1; --tw-pan-x: ; --tw-pan-y: ; --tw-pinch-zoom: ; --tw-scroll-snap-strictness: proximity; --tw-gradient-from-position: ; --tw-gradient-via-position: ; --tw-gradient-to-position: ; --tw-ordinal: ; --tw-slashed-zero: ; --tw-numeric-figure: ; --tw-numeric-spacing: ; --tw-numeric-fraction: ; --tw-ring-inset: ; --tw-ring-offset-width: 0px; --tw-ring-offset-color: #fff; --tw-ring-color: rgb(67 128 180 / .5); --tw-ring-offset-shadow: 0 0 #0000; --tw-ring-shadow: 0 0 #0000; --tw-shadow: 0 0 #0000; --tw-shadow-colored: 0 0 #0000; --tw-blur: ; --tw-brightness: ; --tw-contrast: ; --tw-grayscale: ; --tw-hue-rotate: ; --tw-invert: ; --tw-saturate: ; --tw-sepia: ; --tw-drop-shadow: ; --tw-backdrop-blur: ; --tw-backdrop-brightness: ; --tw-backdrop-contrast: ; --tw-backdrop-grayscale: ; --tw-backdrop-hue-rotate: ; --tw-backdrop-invert: ; --tw-backdrop-opacity: ; --tw-backdrop-saturate: ; --tw-backdrop-sepia: ; --tw-contain-size: ; --tw-contain-layout: ; --tw-contain-paint: ; --tw-contain-style: ; margin-top: 1rem; margin-bottom: 1rem; overflow: hidden; border-radius: 0.5rem; border-width: 1px; border-color: rgba(107, 114, 128, 0.2); box-sizing: border-box; border-style: solid; color: rgb(204, 204, 204); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13.008px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
File | Change
-- | --
src/render.py | • Always prints the News and Cases headers.• When the lawsuits list is empty, it now adds the line 새로운 소식이 0건입니다. instead of an empty table.• When the cl_cases list is empty, it now adds the same message for the Cases section.
src/dedup.py | • After deduplication, if no new news items remain, the Markdown section is replaced with 새로운 소식이 0건입니다. (no leading blank line).• Same logic for the Cases table – if there are no new docket entries, the section becomes 새로운 소식이 0건입니다..• Fixed a typo (n_headers → c_headers) that prevented the Cases block from being processed correctly.
Branch | All changes have been committed to a new branch called improve-empty-display and pushed to the remote repository.

</div>